### PR TITLE
Match real and ansible hostnames when bootstrapping fresh EC2 instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Hire/Follow [@analytically](http://twitter.com/analytically). **NEW: Deploys [Hi
 
 ### Requirements
 
-  - [Ansible](http://www.ansibleworks.com/) 1.3 or later
+  - [Ansible](http://www.ansibleworks.com/) 1.4 or later
   - 8+1 Ubuntu 12.04 LTS, 13.04 or 13.10 hosts
   - [Mandrill](http://mandrill.com/) API key for sending emails
   - `ansibler` user in sudo group without sudo password prompt (see Bootstrapping section below)

--- a/bootstrap/bootstrap.yml
+++ b/bootstrap/bootstrap.yml
@@ -13,6 +13,9 @@
 - hosts: all
   sudo: true
   tasks:
+    - name: hostname should match inventory name
+      hostname: name={{ inventory_hostname }}
+
     - name: create user 'ansibler'
       user: name=ansibler groups=sudo generate_ssh_key=yes shell=/bin/bash
 


### PR DESCRIPTION
This changed the box hostnames from e.g. ip-<private-ip> to hslave01. Other
roles and plays seem to assume this is how things are set-up anyway, which is
not true of bog-standard machines from EC2.

Ansible v1.4 now required, since I use the new ‘hostname’ action.
