### PR TITLE
Force install postgresql

### DIFF
--- a/roles/postgresql_server/tasks/main.yml
+++ b/roles/postgresql_server/tasks/main.yml
@@ -12,7 +12,7 @@
       - postgres
 
 - name: install PostgreSQL via apt
-  apt: name={{ item }}
+  apt: name={{ item }} force=yes
   with_items:
     - postgresql-9.1
     - python-psycopg2


### PR DESCRIPTION
it kept failing due to a warning prompt that required manual confirmation when I ran it.
