### PR TITLE
Use FQDNs when referencing cluster machines

### DIFF
--- a/roles/apache2/tasks/main.yml
+++ b/roles/apache2/tasks/main.yml
@@ -8,5 +8,5 @@
   tags: apache
 
 - name: configure apache2 so it doesn't complain 'can't determine fqdn'
-  lineinfile: dest=/etc/apache2/apache2.conf regexp="{{ ansible_hostname }}" line="ServerName {{ ansible_hostname }}"
+  lineinfile: dest=/etc/apache2/apache2.conf regexp="{{ ansible_fqdn }}" line="ServerName {{ ansible_fqdn }}"
   tags: apache

--- a/roles/cdh_hadoop_config/templates/core-site.xml
+++ b/roles/cdh_hadoop_config/templates/core-site.xml
@@ -7,7 +7,7 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://{{ hostvars[groups['namenodes'][0]]['ansible_hostname'] }}</value>
+        <value>hdfs://{{ hostvars[groups['namenodes'][0]]['ansible_fqdn'] }}</value>
         <final>true</final>
     </property>
 

--- a/roles/cdh_hadoop_config/templates/mapred-site.xml
+++ b/roles/cdh_hadoop_config/templates/mapred-site.xml
@@ -11,17 +11,17 @@
 
     <property>
         <name>mapreduce.jobhistory.address</name>
-        <value>{{ hostvars[groups['historyserver'][0]]['ansible_hostname'] }}:10020</value>
+        <value>{{ hostvars[groups['historyserver'][0]]['ansible_fqdn'] }}:10020</value>
     </property>
 
     <property>
         <name>mapreduce.jobhistory.webapp.address</name>
-        <value>{{ hostvars[groups['historyserver'][0]]['ansible_hostname'] }}:19888</value>
+        <value>{{ hostvars[groups['historyserver'][0]]['ansible_fqdn'] }}:19888</value>
     </property>
 
     <property>
         <name>yarn.web-proxy.address</name>
-        <value>{{ hostvars[groups['historyserver'][0]]['ansible_hostname'] }}:8088</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8088</value>
     </property>
 
     <property>

--- a/roles/cdh_hadoop_config/templates/yarn-site.xml
+++ b/roles/cdh_hadoop_config/templates/yarn-site.xml
@@ -6,23 +6,23 @@
 <configuration>
     <property>
         <name>yarn.resourcemanager.resource-tracker.address</name>
-        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_hostname'] }}:8031</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8031</value>
     </property>
     <property>
         <name>yarn.resourcemanager.address</name>
-        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_hostname'] }}:8032</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8032</value>
     </property>
     <property>
         <name>yarn.resourcemanager.scheduler.address</name>
-        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_hostname'] }}:8030</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8030</value>
     </property>
     <property>
         <name>yarn.resourcemanager.admin.address</name>
-        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_hostname'] }}:8033</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8033</value>
     </property>
     <property>
         <name>yarn.resourcemanager.webapp.address</name>
-        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_hostname'] }}:8088</value>
+        <value>{{ hostvars[groups['resourcemanager'][0]]['ansible_fqdn'] }}:8088</value>
     </property>
     <property>
         <description>Classpath for typical applications.</description>

--- a/roles/cdh_hadoop_datanode/templates/rsyslog.conf
+++ b/roles/cdh_hadoop_datanode/templates/rsyslog.conf
@@ -1,4 +1,4 @@
-$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-datanode-{{ ansible_hostname }}.log
+$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-datanode-{{ ansible_fqdn }}.log
 $InputFileTag hadoop-hdfs-datanode:
 $InputFileStateFile state-hadoop-hdfs-datanode-error
 $InputFileSeverity info

--- a/roles/cdh_hadoop_journalnode/templates/rsyslog.conf
+++ b/roles/cdh_hadoop_journalnode/templates/rsyslog.conf
@@ -1,4 +1,4 @@
-$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-journalnode-{{ ansible_hostname }}.log
+$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-journalnode-{{ ansible_fqdn }}.log
 $InputFileTag hadoop-hdfs-journalnode:
 $InputFileStateFile state-hadoop-hdfs-journalnode-error
 $InputFileSeverity info

--- a/roles/cdh_hadoop_namenode/templates/rsyslog.conf
+++ b/roles/cdh_hadoop_namenode/templates/rsyslog.conf
@@ -1,4 +1,4 @@
-$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-namenode-{{ ansible_hostname }}.log
+$InputFileName /var/log/hadoop-hdfs/hadoop-hdfs-namenode-{{ ansible_fqdn }}.log
 $InputFileTag hadoop-hdfs-namenode:
 $InputFileStateFile state-hadoop-hdfs-namenode-error
 $InputFileSeverity info

--- a/roles/cdh_hbase_master/templates/rsyslog.conf
+++ b/roles/cdh_hbase_master/templates/rsyslog.conf
@@ -1,4 +1,4 @@
-$InputFileName /var/log/hbase/hbase-hbase-master-{{ ansible_hostname }}.log
+$InputFileName /var/log/hbase/hbase-hbase-master-{{ ansible_fqdn }}.log
 $InputFileTag hbase-master:
 $InputFileStateFile state-hbase-master-error
 $InputFileSeverity info

--- a/roles/cdh_hbase_regionserver/templates/rsyslog.conf
+++ b/roles/cdh_hbase_regionserver/templates/rsyslog.conf
@@ -1,4 +1,4 @@
-$InputFileName /var/log/hbase/hbase-hbase-regionserver-{{ ansible_hostname }}.log
+$InputFileName /var/log/hbase/hbase-hbase-regionserver-{{ ansible_fqdn }}.log
 $InputFileTag hbase-regionserver:
 $InputFileStateFile state-hbase-regionserver-error
 $InputFileSeverity info

--- a/roles/cdh_hive_config/templates/hive-site.xml
+++ b/roles/cdh_hive_config/templates/hive-site.xml
@@ -21,10 +21,10 @@
 
     <property>
         <name>javax.jdo.option.ConnectionURL</name>
-        {% if hostvars[groups["hive_metastore"][0]]["ansible_hostname"] == ansible_hostname %}
+        {% if hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] == ansible_fqdn %}
         <value>jdbc:postgresql://localhost/metastore</value>
         {% else %}
-        <value>jdbc:postgresql://{{ hostvars[groups["hive_metastore"][0]]["ansible_hostname"] }}/metastore</value>
+        <value>jdbc:postgresql://{{ hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] }}/metastore</value>
         {% endif %}
     </property>
 
@@ -50,7 +50,7 @@
 
     <property>
         <name>hive.metastore.uris</name>
-        <value>thrift://{{ hostvars[groups["hive_metastore"][0]]["ansible_hostname"] }}:9083</value>
+        <value>thrift://{{ hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] }}:9083</value>
         <description>IP address (or fully-qualified domain name) and port of the metastore host</description>
     </property>
 

--- a/roles/common/templates/hosts
+++ b/roles/common/templates/hosts
@@ -3,5 +3,5 @@
 127.0.0.1 localhost
 
 {% for host in groups['all'] %}
-{{ hostvars[host]["ansible_default_ipv4"]["address"] }} {{ hostvars[host]["ansible_hostname"] }}
+{{ hostvars[host]["ansible_default_ipv4"]["address"] }} {{ hostvars[host]["ansible_fqdn"] }} {{ hostvars[host]["ansible_hostname"] }}
 {% endfor %}

--- a/roles/rsyslog_fluentd/handlers/main.yml
+++ b/roles/rsyslog_fluentd/handlers/main.yml
@@ -5,4 +5,4 @@
   service: name=rsyslog state=restarted
 
 - name: log installation message
-  shell: logger -t ansible "Configured rsyslog integration with Fluentd on {{ ansible_hostname }}"
+  shell: logger -t ansible "Configured rsyslog integration with Fluentd on {{ ansible_fqdn }}"

--- a/roles/smokeping/templates/General
+++ b/roles/smokeping/templates/General
@@ -12,7 +12,7 @@ contact = root@localhost
 # NOTE: do not put the Image Cache below cgi-bin
 # since all files under cgi-bin will be executed ... this is not
 # good for images.
-cgiurl = http://{{ hostvars[groups["monitors"][0]]["ansible_hostname"] }}/cgi-bin/smokeping.cgi
+cgiurl = http://{{ hostvars[groups["monitors"][0]]["ansible_fqdn"] }}/cgi-bin/smokeping.cgi
 
 # specify this to get syslog logging
 syslogfacility = local0

--- a/roles/smokeping/templates/Targets
+++ b/roles/smokeping/templates/Targets
@@ -20,7 +20,7 @@ title = Hadoop Namenodes
 +++ {{ hostvars[host]['ansible_hostname'] }}
 menu = {{ hostvars[host]['ansible_hostname'] }}
 title = Namenode {{ hostvars[host]['ansible_hostname'] }} at {{ hostvars[host]['ansible_default_ipv4']['address'] }}
-host = {{ hostvars[host]['ansible_hostname'] }}
+host = {{ hostvars[host]['ansible_fqdn'] }}
 alerts = bigloss,someloss,startloss,rttdetect,hostdown
 {% endfor %}
 
@@ -32,6 +32,6 @@ title = Hadoop Datanodes
 +++ {{ hostvars[host]['ansible_hostname'] }}
 menu = {{ hostvars[host]['ansible_hostname'] }}
 title = Datanode {{ hostvars[host]['ansible_hostname'] }} at {{ hostvars[host]['ansible_default_ipv4']['address'] }}
-host = {{ hostvars[host]['ansible_hostname'] }}
+host = {{ hostvars[host]['ansible_fqdn'] }}
 alerts = bigloss,someloss,startloss,rttdetect,hostdown
 {% endfor %}


### PR DESCRIPTION
Here it is :) I think amirhhz/hadoop-ansible@51d5ca9 and amirhhz/hadoop-ansible@4011380 should really accompany this in some form, what do you think?

------ [ from commit message:] ------

The following points are worth recording for future reference:
- To make sure ansible reports the correct FQDN for each machine, the
  FQDN needs to be present in the /etc/hosts file. Even if the hostname
  of a machine is set to the FQDN, ansible cuts it short at the first
  period. I'm not sure I like this, but that's how it is even, after a
  fair amount of discussion on ansible's devel list and github issues;
- The rsyslog.conf files also change to look for files with the FQDN in
  them because the behaviour of the hadoop ecosystem tools is to use the
  full hostname (not truncated) output of the 'hostname' command to
  determine the name of the log files.

Conflicts (due to cherry-picking, all in files that don't exist in
master any longer):

```
roles/cdh_hadoop_config/templates/mapred-site.xml
roles/cdh_oozie/templates/oozie-site.xml
roles/logstash_index_cleaner/templates/logstash-index-cleaner.cron.d
```
