### PR TITLE
Add option to use mysql_server as hive_metastore

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -9,3 +9,6 @@ mtu: 9216
 # postfix_domain: example.com
 # mandrill_username: your_username
 # mandrill_api_key: your_api_key
+
+# Choose postgresql or mysql as hive metastore
+metastore: postgresql

--- a/roles/cdh_hive_config/tasks/main.yml
+++ b/roles/cdh_hive_config/tasks/main.yml
@@ -25,4 +25,11 @@
 
 - name: soft link postgresql-jdbc4.jar
   shell: creates=/usr/lib/hive/lib/postgresql-jdbc4.jar ln -s /usr/share/java/postgresql-jdbc4.jar /usr/lib/hive/lib/postgresql-jdbc4.jar
+  when: metastore == "postgresql"
   tags: hive
+
+
+- name: symbolically link libmysql-java.jar
+  shell: creates=/usr/lib/hive/lib/libmysql-java.jar
+         ln -s /usr/share/java/mysql-connector-java.jar /usr/lib/hive/lib/libmysql-java.jar 
+  when: metastore == "mysql"

--- a/roles/cdh_hive_config/templates/hive-site.xml
+++ b/roles/cdh_hive_config/templates/hive-site.xml
@@ -22,15 +22,20 @@
     <property>
         <name>javax.jdo.option.ConnectionURL</name>
         {% if hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] == ansible_fqdn %}
-        <value>jdbc:postgresql://localhost/metastore</value>
+        <value>jdbc:{{ metastore }}://localhost/metastore</value>
         {% else %}
-        <value>jdbc:postgresql://{{ hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] }}/metastore</value>
+        <value>jdbc:{{ metastore }}://{{ hostvars[groups["hive_metastore"][0]]["ansible_fqdn"] }}/metastore</value>
         {% endif %}
     </property>
 
     <property>
         <name>javax.jdo.option.ConnectionDriverName</name>
+        {% if metastore == postgresql %}
         <value>org.postgresql.Driver</value>
+        {% endif %}
+        {% if metastore == mysql %}
+        <value>com.mysql.jdbc.Driver</value>
+        {% endif %}
     </property>
 
     <property>

--- a/roles/mysql_server/tasks/main.yml
+++ b/roles/mysql_server/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+# file: roles/mysql_server/tasks/main.yml
+
+- name: predefine mysql root passwd
+  shell: executable=/bin/bash
+         create=/root/.mysql-root-passwd-configured
+         debconf-set-selections <<< "mysql-server-5.5 mysql-server/root_password password hive_{{ site_name }}"
+
+- name: predefine mysql root passwd confirm
+  shell: executable=/bin/bash
+         create=/root/.mysql-root-passwd-again-configured
+         debconf-set-selections <<< "mysql-server-5.5 mysql-server/root_password_again password hive_{{ site_name }}"
+
+- name: install MySQL and related-package via apt
+  apt: name={{ item }}
+       update_cache=yes
+  with_items:
+    - mysql-server-5.5
+    - libmysql-java
+    - python-mysqldb
+
+- name: service mysql restart
+  service: name=mysql
+           state=restarted
+
+- name: create mysql db 'metastore'
+  mysql_db: name=metastore
+            state=present
+            login_user=root
+            login_password=hive_{{ site_name }}
+
+- name: init metastore schema
+  shell: mysql -uroot -phive_{{ site_name }} metastore < /usr/lib/hive/scripts/metastore/upgrade/mysql/hive-schema-0.10.0.mysql.sql
+
+- name: add mysql user 'hiveuser'
+  mysql_user: name=hiveuser
+              host=localhost
+              password=hive_{{ site_name }}
+              priv=metastore.*:ALL
+              state=present
+              login_user=root
+              login_password=hive_{{ site_name }}

--- a/roles/postgresql_server/tasks/main.yml
+++ b/roles/postgresql_server/tasks/main.yml
@@ -20,3 +20,35 @@
 - name: install PostgreSQL contrib via apt
   apt: name=postgresql-contrib-9.1 force=yes
   tags: postgres
+
+- name: create postgresql db 'metastore'
+  sudo: true
+  sudo_user: postgres
+  postgresql_db: name=metastore
+  tags:
+    - postgres
+    - hive
+
+- name: add postgresql user 'hiveuser'
+  sudo: true
+  sudo_user: postgres
+  postgresql_user: db=metastore name=hiveuser password=hive_{{ site_name }} priv=CONNECT
+  tags:
+    - postgres
+    - hive
+
+- name: init metastore schema
+  sudo: true
+  sudo_user: postgres
+  shell: psql --dbname=metastore --file=/usr/lib/hive/scripts/metastore/upgrade/postgres/hive-schema-0.10.0.postgres.sql
+  tags:
+    - postgres
+    - hive
+
+- name: grant hiveuser
+  sudo: true
+  sudo_user: postgres
+  shell: psql --dbname=metastore --command="GRANT ALL ON ALL TABLES IN SCHEMA public TO hiveuser;"
+  tags:
+    - postgres
+    - hive

--- a/site.yml
+++ b/site.yml
@@ -252,31 +252,9 @@
   user: ansibler
   sudo: true
   roles:
-    - postgresql_server
+    - { role: postgresql_server, when metastore == "postgresql" }
+    - { role: mysql_server, when metastore == "mysql" }
     - cdh_hive_config
-
-- hosts: hive_metastore
-  accelerate: "{{ accelerate }}"
-  user: ansibler
-  sudo: true
-  sudo_user: postgres
-  tasks:
-    - postgresql_db: name=metastore
-      tags:
-        - postgres
-        - hive
-    - postgresql_user: db=metastore name=hiveuser password=hive_{{ site_name }} priv=CONNECT
-      tags:
-        - postgres
-        - hive
-    - shell: psql --dbname=metastore --file=/usr/lib/hive/scripts/metastore/upgrade/postgres/hive-schema-0.10.0.postgres.sql
-      tags:
-        - postgres
-        - hive
-    - shell: psql --dbname=metastore --command="GRANT ALL ON ALL TABLES IN SCHEMA public TO hiveuser;"
-      tags:
-        - postgres
-        - hive
 
 - hosts: hive_metastore
   accelerate: "{{ accelerate }}"


### PR DESCRIPTION
Add option to use mysql_server as hive_metastore
### Changes
- add roles/mysql_server/*
- In group_vars/all
  - `metastore: postgresql/mysql`
- In roles/cdh_hive_config/
  - modify hive configure template
  - add mysql java connector
- move //Create hive database and user in postgresql// into //roles/postgresql_server//
- In site.yml
  - choose metastore role by group var
